### PR TITLE
Add 3-layer anti-crash defense for NativeAOT GC

### DIFF
--- a/Hytale/Hooks/HookedMethods/FrameIterator_IsValid.cpp
+++ b/Hytale/Hooks/HookedMethods/FrameIterator_IsValid.cpp
@@ -18,6 +18,7 @@ bool __fastcall Hooks::hkFrameIterator_IsValid(GCInstance* instance) {
         instance->pConservativeStackRangeLowerBound = 0x0;
         instance->pConservativeStackRangeUpperBound = 0x0;
         instance->flags |= GCFlag::MethodStateCalculated;
+        instance->flags |= GCFlag::ActiveStackFrame;
         instance->flags |= GCFlag::SkipNativeFrames;
         return false;
     }

--- a/Hytale/Hooks/Hooks.cpp
+++ b/Hytale/Hooks/Hooks.cpp
@@ -3,6 +3,8 @@
  */
 #include "Core.h"
 #include "Hooks.h"
+#include "Util/AntiCrash.h"
+#include "Util/TrampolineUnwind.h"
 
 // Helper macros for creating hooks
 // These macros simplify the process of creating hooks by combining pattern scanning and hook creation into a single step. They also log the addresses found for easier debugging.
@@ -10,21 +12,26 @@
 if (MH_CreateHook((LPVOID)name##Address, &hk##name, reinterpret_cast<LPVOID*>(&o##name)) != MH_OK) {\
     Util::log("Failed to hook %s\n", #name);\
     return false;\
-}
+}\
+TrampolineUnwind::Register(reinterpret_cast<void*>(o##name), reinterpret_cast<void*>(name##Address), 64);
+
 #define CREATE_SIG_HOOK(name, pattern) \
 std::uintptr_t name##Address = Util::PatternScan(pattern);\
 Util::log("Found %s sig at: 0x%llX - 0x%llX = 0x%lX\n", #name, name##Address, gameBase, (name##Address - gameBase));\
 if (MH_CreateHook((LPVOID)name##Address, &hk##name, reinterpret_cast<LPVOID*>(&o##name)) != MH_OK) {\
     Util::log("Failed to hook %s\n", #name);\
     return false;\
-}
+}\
+TrampolineUnwind::Register(reinterpret_cast<void*>(o##name), reinterpret_cast<void*>(name##Address), 64);
+
 #define CREATE_SIG_HOOK_BY_REF(name, pattern) \
 std::uintptr_t name##Address = Util::RelativeVirtualAddress(Util::PatternScan(pattern), 1, 5);\
 Util::log("Found %s sig at: 0x%llX - 0x%llX = 0x%lX\n", #name, name##Address, gameBase, (name##Address - gameBase));\
 if (MH_CreateHook((LPVOID)name##Address, &hk##name, reinterpret_cast<LPVOID*>(&o##name)) != MH_OK) {\
     Util::log("Failed to hook %s\n", #name);\
     return false;\
-}
+}\
+TrampolineUnwind::Register(reinterpret_cast<void*>(o##name), reinterpret_cast<void*>(name##Address), 64);
 
 /*
 * Creates and registers all hooks
@@ -37,12 +44,12 @@ bool Hooks::CreateHooks() {
         return false;
     }
 
-    std::uintptr_t WglSwapBuffersAddress = (uint64_t) GetProcAddress(GetModuleHandleA("opengl32.dll"), "wglSwapBuffers");
+    std::uintptr_t WglSwapBuffersAddress = reinterpret_cast<uint64_t>(GetProcAddress(GetModuleHandleA("opengl32.dll"), "wglSwapBuffers"));
     ValidPtrBool(WglSwapBuffersAddress);
 
     CREATE_HOOK(WglSwapBuffers);
-    CREATE_SIG_HOOK(FrameIterator_IsValid, "48 83 79 ? ? 0F 95 C0 C3 CC CC CC CC CC CC CC 40 53"); // E8 ? ? ? ? 84 C0 0F 85 ? ? ? ? 49 8B 5D
-    CREATE_SIG_HOOK(WeatherUpdate, "41 57 41 56 41 55 41 54 57 56 55 53 48 81 EC ? ? ? ? 0F 29 B4 24 ? ? ? ? 0F 29 BC 24 ? ? ? ? 44 0F 29 84 24 ? ? ? ? 44 0F 29 8C 24 ? ? ? ? 0F 57 E4 0F 29 64 24 ? 0F 29 64 24 ? 48 B8"); //E8 ? ? ? ? 48 8B 4B ? 48 8B 49 ? BA ? ? ? ? 39 09 E8 ? ? ? ? 80 BB ? ? ? ? ? 75 ? 48 8B 8B ? ? ? ? F3 0F 10 8B ? ? ? ? 39 09 E8 ? ? ? ? 48 8B 8B
+    CREATE_SIG_HOOK(FrameIterator_IsValid, "48 83 79 ? ? 0F 95 C0 C3 CC CC CC CC CC CC CC 40 53");
+    CREATE_SIG_HOOK(WeatherUpdate, "41 57 41 56 41 55 41 54 57 56 55 53 48 81 EC ? ? ? ? 0F 29 B4 24 ? ? ? ? 0F 29 BC 24 ? ? ? ? 44 0F 29 84 24 ? ? ? ? 44 0F 29 8C 24 ? ? ? ? 0F 57 E4 0F 29 64 24 ? 0F 29 64 24 ? 48 B8");
     CREATE_SIG_HOOK_BY_REF(DoMoveCycle, "E8 ? ? ? ? FF CE 75 ? 48 8B 4B");
     CREATE_SIG_HOOK_BY_REF(HandleScreenShotting, "E8 ? ? ? ? 4C 8B 7D ? 49 8B 8F ? ? ? ? 39 09");
     CREATE_SIG_HOOK_BY_REF(OnUserInput, "E8 ? ? ? ? 49 8B 47 ? C6 80");
@@ -50,6 +57,7 @@ bool Hooks::CreateHooks() {
     CREATE_SIG_HOOK_BY_REF(DrawEntityCharactersAndItems, "E8 ? ? ? ? 48 8B 4B ? 48 8B 49 ? BA ? ? ? ? 39 09 E8 ? ? ? ? 48 8B 85");
     CREATE_SIG_HOOK_BY_REF(DrawScene, "E8 ? ? ? ? 80 7B ? ? 75 ? 48 89 5D");
 
+    AntiCrash::Install();
     MH_EnableHook(MH_ALL_HOOKS);
 
     Util::log("All Hooks created and registered successfully\n");

--- a/Hytale/Hytale.vcxproj
+++ b/Hytale/Hytale.vcxproj
@@ -210,6 +210,8 @@
     <ClCompile Include="Util\RenderUtils.cpp" />
     <ClCompile Include="Util\TimeUtil.cpp" />
     <ClCompile Include="Util\Util.cpp" />
+    <ClCompile Include="Util\AntiCrash.cpp" />
+    <ClCompile Include="Util\TrampolineUnwind.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Events\EventRegister.h" />
@@ -398,6 +400,8 @@
     <ClInclude Include="Core.h" />
     <ClInclude Include="Util\FileUtil.h" />
     <ClInclude Include="Util\Util.h" />
+    <ClInclude Include="Util\AntiCrash.h" />
+    <ClInclude Include="Util\TrampolineUnwind.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="external\imgui-1.92.5\examples\libs\emscripten\shell_minimal.html" />

--- a/Hytale/Hytale.vcxproj.filters
+++ b/Hytale/Hytale.vcxproj.filters
@@ -75,6 +75,12 @@
     <ClCompile Include="Util\Util.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Util\AntiCrash.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Util\TrampolineUnwind.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="sdk\Time.h">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -264,6 +270,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Util\Util.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Util\AntiCrash.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Util\TrampolineUnwind.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Math\Matrix4x4.h">

--- a/Hytale/Util/AntiCrash.cpp
+++ b/Hytale/Util/AntiCrash.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) FishPlusPlus.
+ */
+#include "AntiCrash.h"
+#include "Util/Util.h"
+#include <windows.h>
+#include "external/minhook/minhook.h"
+
+namespace {
+
+using fn_RaiseFailFastException = void(WINAPI*)(PEXCEPTION_RECORD, PCONTEXT, DWORD);
+using fn_RtlFailFast = void(WINAPI*)(ULONG);
+using fn_TerminateProcess = BOOL(WINAPI*)(HANDLE, UINT);
+using fn_ExitProcess = void(WINAPI*)(UINT);
+using fn_NtTerminateProcess = LONG(NTAPI*)(HANDLE, LONG);
+using fn_RtlExitUserProcess = void(WINAPI*)(ULONG);
+
+fn_RaiseFailFastException  oRaiseFailFastException  = nullptr;
+fn_RtlFailFast             oRtlFailFast             = nullptr;
+fn_TerminateProcess        oTerminateProcess         = nullptr;
+fn_ExitProcess             oExitProcess              = nullptr;
+fn_NtTerminateProcess      oNtTerminateProcess       = nullptr;
+fn_RtlExitUserProcess      oRtlExitUserProcess       = nullptr;
+
+void WINAPI hkRaiseFailFastException(PEXCEPTION_RECORD, PCONTEXT, DWORD dwFlags) {
+    Util::log("[AntiCrash] RaiseFailFastException intercepted (flags=0x%08X)\n", dwFlags);
+}
+
+void WINAPI hkRtlFailFast(ULONG Code) {
+    Util::log("[AntiCrash] RtlFailFast intercepted (code=%lu)\n", Code);
+}
+
+BOOL WINAPI hkTerminateProcess(HANDLE hProcess, UINT uExitCode) {
+    if (hProcess == GetCurrentProcess() || hProcess == reinterpret_cast<HANDLE>(-1)) {
+        Util::log("[AntiCrash] TerminateProcess suppressed (code=0x%08X)\n", uExitCode);
+        return TRUE;
+    }
+    return oTerminateProcess(hProcess, uExitCode);
+}
+
+void WINAPI hkExitProcess(UINT uExitCode) {
+    Util::log("[AntiCrash] ExitProcess suppressed (code=0x%08X)\n", uExitCode);
+}
+
+LONG NTAPI hkNtTerminateProcess(HANDLE ProcessHandle, LONG ExitStatus) {
+    if (ProcessHandle == GetCurrentProcess() || ProcessHandle == reinterpret_cast<HANDLE>(-1) || ProcessHandle == nullptr) {
+        Util::log("[AntiCrash] NtTerminateProcess suppressed (status=0x%08X)\n", ExitStatus);
+        return 0;
+    }
+    return oNtTerminateProcess(ProcessHandle, ExitStatus);
+}
+
+void WINAPI hkRtlExitUserProcess(ULONG ExitStatus) {
+    Util::log("[AntiCrash] RtlExitUserProcess suppressed (status=0x%08X)\n", ExitStatus);
+}
+
+void HookByName(const char* mod, const char* func, void* detour, void** ppOrig) {
+    HMODULE hMod = GetModuleHandleA(mod);
+    if (!hMod) return;
+    auto* pFunc = reinterpret_cast<void*>(GetProcAddress(hMod, func));
+    if (!pFunc) return;
+    if (MH_CreateHook(pFunc, detour, ppOrig) == MH_OK)
+        Util::log("[AntiCrash] Hooked %s::%s\n", mod, func);
+}
+
+}
+
+namespace AntiCrash {
+
+void Install() {
+    HookByName("kernelbase.dll", "RaiseFailFastException", reinterpret_cast<void*>(hkRaiseFailFastException), reinterpret_cast<void**>(&oRaiseFailFastException));
+    HookByName("ntdll.dll", "RtlFailFast", reinterpret_cast<void*>(hkRtlFailFast), reinterpret_cast<void**>(&oRtlFailFast));
+    HookByName("kernel32.dll", "TerminateProcess", reinterpret_cast<void*>(hkTerminateProcess), reinterpret_cast<void**>(&oTerminateProcess));
+    HookByName("kernel32.dll", "ExitProcess", reinterpret_cast<void*>(hkExitProcess), reinterpret_cast<void**>(&oExitProcess));
+    HookByName("ntdll.dll", "NtTerminateProcess", reinterpret_cast<void*>(hkNtTerminateProcess), reinterpret_cast<void**>(&oNtTerminateProcess));
+    HookByName("ntdll.dll", "RtlExitUserProcess", reinterpret_cast<void*>(hkRtlExitUserProcess), reinterpret_cast<void**>(&oRtlExitUserProcess));
+}
+
+}

--- a/Hytale/Util/AntiCrash.h
+++ b/Hytale/Util/AntiCrash.h
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) FishPlusPlus.
+ */
+#pragma once
+
+namespace AntiCrash {
+void Install();
+}

--- a/Hytale/Util/TrampolineUnwind.cpp
+++ b/Hytale/Util/TrampolineUnwind.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) FishPlusPlus.
+ */
+#include "TrampolineUnwind.h"
+#include <vector>
+#include <mutex>
+
+namespace {
+
+struct UnwindRegistration {
+    void* allocBlock;
+    bool  registered;
+};
+
+std::mutex g_mutex;
+std::vector<UnwindRegistration> g_registrations;
+
+}
+
+namespace TrampolineUnwind {
+
+void Register(void* pTrampoline, void* pOriginalFunction, uint32_t trampolineSize) {
+    if (!pTrampoline || !pOriginalFunction || trampolineSize == 0)
+        return;
+
+    DWORD64 imageBase = 0;
+    auto* pOrigRF = RtlLookupFunctionEntry(
+        reinterpret_cast<DWORD64>(pOriginalFunction), &imageBase, nullptr);
+    if (!pOrigRF)
+        return;
+
+    auto* pOrigUI = reinterpret_cast<uint8_t*>(imageBase + pOrigRF->UnwindInfoAddress);
+    uint8_t countOfCodes = pOrigUI[2];
+    uint32_t codesSize = countOfCodes * 2;
+    if (codesSize & 7) codesSize = (codesSize + 7) & ~7u;
+    uint8_t flags = (pOrigUI[0] >> 3) & 0x1F;
+
+    uint32_t uiSize = 4 + codesSize;
+    if (flags & 0x04)       uiSize += 12;
+    else if (flags & 0x03)  uiSize += 4;
+
+    auto blockSize = static_cast<uint32_t>(sizeof(RUNTIME_FUNCTION) + uiSize);
+    auto* pBlock = VirtualAlloc(nullptr, blockSize, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+    if (!pBlock) return;
+
+    auto base = reinterpret_cast<uintptr_t>(pBlock);
+    auto* pRF = reinterpret_cast<RUNTIME_FUNCTION*>(pBlock);
+    auto* pUI = reinterpret_cast<uint8_t*>(base + sizeof(RUNTIME_FUNCTION));
+
+    memcpy(pUI, pOrigUI, uiSize);
+
+    pRF->BeginAddress = static_cast<DWORD>(reinterpret_cast<uintptr_t>(pTrampoline) - base);
+    pRF->EndAddress   = pRF->BeginAddress + trampolineSize;
+    pRF->UnwindInfoAddress = static_cast<DWORD>(sizeof(RUNTIME_FUNCTION));
+
+    BOOLEAN ok = RtlAddFunctionTable(pRF, 1, base);
+
+    std::lock_guard lock(g_mutex);
+    g_registrations.push_back({ pBlock, ok != 0 });
+}
+
+void CleanupAll() {
+    std::lock_guard lock(g_mutex);
+    for (auto& reg : g_registrations) {
+        if (reg.registered)
+            RtlDeleteFunctionTable(reinterpret_cast<PRUNTIME_FUNCTION>(reg.allocBlock));
+        if (reg.allocBlock)
+            VirtualFree(reg.allocBlock, 0, MEM_RELEASE);
+    }
+    g_registrations.clear();
+}
+
+}

--- a/Hytale/Util/TrampolineUnwind.h
+++ b/Hytale/Util/TrampolineUnwind.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) FishPlusPlus.
+ */
+#pragma once
+
+#include <windows.h>
+#include <cstdint>
+
+namespace TrampolineUnwind {
+void Register(void* pTrampoline, void* pOriginalFunction, uint32_t trampolineSize);
+void CleanupAll();
+}


### PR DESCRIPTION
- Add AntiCrash hooks: suppress RaiseFailFastException, RtlFailFast, TerminateProcess, ExitProcess, NtTerminateProcess, RtlExitUserProcess
- Add TrampolineUnwind: register RUNTIME_FUNCTION via RtlAddFunctionTable for MinHook trampolines so the GC stack walker can unwind through them
- Wire TrampolineUnwind::Register into hook creation macros
- Add ActiveStackFrame flag to FrameIterator_IsValid hook